### PR TITLE
Added github repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Provides functions to work with 'incidence2' objects, including a
   simplified interface for trend fitting and peak estimation. This package is
   part of the RECON (<https://www.repidemicsconsortium.org/>) toolkit for 
   outbreak analysis (<https://www.reconverse.org/).
-URL: https://www.reconverse.org/i2extras/
+URL: https://www.reconverse.org/i2extras/, https://github.com/reconverse/i2extras/
 BugReports: https://github.com/reconverse/i2extras/issues
 Encoding: UTF-8
 License: MIT + file LICENSE


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

From a technical point of view, this is useful for allowing autolinking in pkgdown websites. Here is the explanation: https://pkgdown.r-lib.org/articles/linking.html?q=cross#across-packages

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION     